### PR TITLE
fix(player): fix issue with player trying to start when there's no video

### DIFF
--- a/src/app/bootstrap.tsx
+++ b/src/app/bootstrap.tsx
@@ -110,7 +110,7 @@ class Bootstrap {
     if (!wrapper) {
       wrapper = document.querySelector("#showmedia_video_box_wide");
     }
-    if (!wrapper) {
+    if (!wrapper && document.querySelector("#content > #the_embedded_player")) {
       wrapper = document.querySelector("#content");
     }
     if (!wrapper) throw new Error("Not able to find video wrapper.");


### PR DESCRIPTION
Fixes #46.

The problem is that the player will look for the `#content` element but the `#content` element is not always a video. The reason the player is looking for `#content` is to make sure that it can play embedded videos.