### PR TITLE
Adapt variable name for next video feature in vilos

### DIFF
--- a/src/app/services/VilosPlayerService.ts
+++ b/src/app/services/VilosPlayerService.ts
@@ -57,7 +57,7 @@ export class VilosPlayerService implements IMediaService {
 
     const nextMediaUrl = get<string>(
       html,
-      /^\W*nextMediaLink = (("|')http(.*?));$/m
+      /^\W*var nextMediaUrl = (("|')https?(.*?));$/m
     );
 
     if (!media || !analytics || !playerLanguage || !playerMetadata)


### PR DESCRIPTION
Fixes the broken next video feature for me - it seems like crunchyroll changed the nextMediaLink variable name for the vilos? player, leading to no nextMediaUrl.