### PR TITLE
Implement playback rate persistent through videos

### DIFF
--- a/src/app/bootstrap.tsx
+++ b/src/app/bootstrap.tsx
@@ -14,6 +14,7 @@ import {
   getAutoPlay,
   getMediaId,
   getQualitySettings,
+  getStoredPlaybackRate,
   getStartTime,
   updateSelectedElement
 } from './player/StandardPlayer';
@@ -101,6 +102,7 @@ async function _runOnInteractive() {
 
   const storage = container.get<IStorage>(IStorageSymbol);
   const large = await storage.get<boolean>('large');
+  const rate = await getStoredPlaybackRate();
 
   if (large !== undefined) {
     updateSize(large);
@@ -110,7 +112,8 @@ async function _runOnInteractive() {
   let mediaId = getMediaId(url);
   const options = {
     sizeEnabled: true,
-    autoPlay: true
+    autoPlay: true,
+    playbackRate: rate
   } as IPlayerControllerOptions;
 
   if (mediaId) {

--- a/src/app/media/player/Player.tsx
+++ b/src/app/media/player/Player.tsx
@@ -56,6 +56,7 @@ export interface IPlayerConfig {
   duration?: number;
   nextVideo?: IVideoDetail;
   startTime?: number;
+  playbackRate?: number;
   autoplay?: boolean;
   volume?: number;
   muted?: boolean;
@@ -615,7 +616,7 @@ export class Player extends Component<IPlayerProps, IPlayerState>
       const resolver = container.get<IQualityResolver>(IQualityResolverSymbol);
       resolver.bind(this._chromelessPlayer, hls);
 
-      this._chromelessPlayer.setVideoSource(hls, config.startTime);
+      this._chromelessPlayer.setVideoSource(hls, config.startTime, config.playbackRate);
     } else {
       this._chromelessPlayer.removeVideoSource();
     }

--- a/src/app/player/PlayerController.tsx
+++ b/src/app/player/PlayerController.tsx
@@ -39,6 +39,7 @@ export interface IPlayerControllerOptions {
   quality?: keyof Formats;
   mediaFormat?: string;
   mediaQuality?: string;
+  playbackRate?: number;
 
   startTime?: number;
   sizeEnabled?: boolean;
@@ -68,6 +69,7 @@ export class PlayerController {
   private _quality?: keyof Formats;
   private _mediaFormat?: string;
   private _mediaQuality?: string;
+  private _playbackRate?: number;
 
   private _player?: Player;
   private _playerActionController?: StaticActionController;
@@ -101,6 +103,7 @@ export class PlayerController {
       this._autoPlay = options.autoPlay;
       this._affiliateId = options.affiliateId;
       this._quality = options.quality ? options.quality : undefined;
+      this._playbackRate = options.playbackRate;
 
       this._mediaFormat = options.mediaFormat;
       this._mediaQuality = options.mediaQuality;
@@ -197,7 +200,8 @@ export class PlayerController {
       autoplay:
         this._autoPlay === undefined ? media.isAutoPlay() : this._autoPlay,
       thumbnailUrl: media.getThumbnailUrl(),
-      quality: this._quality
+      quality: this._quality,
+      playbackRate: this._playbackRate
     } as IPlayerConfig;
 
     // Change the file URL to https if current page is also https

--- a/src/app/player/StandardPlayer.ts
+++ b/src/app/player/StandardPlayer.ts
@@ -114,6 +114,19 @@ export function updateSelectedElement(quality: string): void {
   }
 }
 
+export async function getStoredPlaybackRate(): Promise<number | undefined> {
+    const storage = container.get<IStorage>(IStorageSymbol);
+
+    return await storage.get<number>('playbackRate');
+}
+
+export async function setStoredPlaybackRate(rate?: number): Promise<void> {
+    const storage = container.get<IStorage>(IStorageSymbol);
+
+    return await storage.set<number>('playbackRate', rate);
+}
+
+
 export async function getStoredQuality(): Promise<keyof Formats | undefined> {
   const storage = container.get<IStorage>(IStorageSymbol);
 

--- a/src/app/settings/PlaybackRateSettings.ts
+++ b/src/app/settings/PlaybackRateSettings.ts
@@ -6,6 +6,7 @@ import {
 } from '../media/player/chrome/SettingsPopup';
 import { IPlayerApi } from '../media/player/IPlayerApi';
 import { ISettingsModule } from '../models/ISettingsModule';
+import { setStoredPlaybackRate } from '../player/StandardPlayer';
 
 export class PlaybackRateSettings extends EventTarget
   implements ISettingsModule {
@@ -55,8 +56,9 @@ export class PlaybackRateSettings extends EventTarget
     this._handler.removeAll();
   }
 
-  private _setPlaybackRate(rate: number) {
+  private async _setPlaybackRate(rate: number) {
     this._api.setPlaybackRate(rate);
+    await setStoredPlaybackRate(rate);
 
     this.dispatchEvent('navigateToCurrent');
   }


### PR DESCRIPTION
Hi, I've been watching a lot of animes lately, one after the other, and one thing that annoyed me was that I had to change the playback rate every time I changed an episode, mainly on fullscreen mode. So, I'm sending the PR to make the playback rate persistent through the episodes.

What do you think? Do I need to change something?

Thanks in advance