### PR TITLE
Hide settings popup when clicked outside of popup

### DIFF
--- a/src/app/media/player/Player.tsx
+++ b/src/app/media/player/Player.tsx
@@ -958,6 +958,10 @@ export class Player extends Component<IPlayerProps, IPlayerState>
       this._actionClickTimer = undefined;
       this._actionClickExecuted = true;
 
+      if (api.isSettingsOpen()) {
+        api.closeSettings();
+      }
+
       const isPlaying =
         api.getPreferredPlaybackState() === PlaybackState.PLAYING;
       if (isPlaying) {


### PR DESCRIPTION
Hi I'd like to contribute to your project and I'm sending a quick "fix" about settings popup. When it is open, if you click outside of it (eg: to pause/play the video), the popup will stay open and that be in front of a part of the video. It's a simple PR, just a simple check. 

What do you think? 
Thanks for your time